### PR TITLE
Don't default to us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,23 @@ once per day.
 
 ## Usage
 
-Run the deploy script and optionally specify the number of days for which
-snapshots should be retained. If this parameter is omitted, the function will
-keep snapshots for 30 days.
+To install this function, ensure you have the [AWS Command Line Interface
+(AWS CLI)][cli] installed and configured.
 
-This will create all resources in US East (N. Virginia) as it is the only
-Region that currently supports Amazon Lightsail.
+Run the deploy script and optionally specify the region to install the function
+and the number of days for which snapshots should be retained. By default, the
+script will install the function into your default configured region and retain
+snapshots for 30 days.
 
 ```console
-bin/deploy [RETENTION_DAYS]
+## Install in US East (Ohio) and retain snapshots for 15 days
+REGION=us-east-2 DAYS=15 bin/deploy
+
+## Install in the CLI's configured default region and retain snapshots for 90 days
+DAYS=90 bin/deploy
+
+## Install in EU (Ireland) and retain snapshots for 30 days
+REGION=eu-west-1 bin/deploy
 ```
 
 ## License
@@ -29,3 +37,5 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
 [http://aws.amazon.com/apache2.0/](http://aws.amazon.com/apache2.0/)
 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+[cli]: https://aws.amazon.com/documentation/cli/

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-set -o errexit -o xtrace
+set -o errexit
 
-region=us-east-1
-retention_days=${1:-30}
+days=${DAYS:-30}
+region=${REGION:-$(aws configure get region)}
+
 bucket_name="temp-lightsail-auto-snapshots-$(openssl rand -hex 8)"
 
-aws s3 mb "s3://${bucket_name}" --region="${region}"
+aws s3 mb "s3://${bucket_name}" --region $region
 
 aws cloudformation package \
   --output-template-file deploy/output.yaml \
   --template-file lightsail-auto-snapshots.yaml \
-  --s3-bucket="${bucket_name}" \
-  --region="${region}"
+  --s3-bucket="${bucket_name}"
 
 aws cloudformation deploy \
   --template-file deploy/output.yaml \
   --stack-name LightsailAutoSnapshots \
   --capabilities CAPABILITY_NAMED_IAM \
-  --parameter-overrides "RetentionDays=${retention_days}" \
-  --region="${region}"
+  --parameter-overrides "RetentionDays=${days}" \
+  --region $region
 
-aws s3 rb --force "s3://${bucket_name}" --region="${region}"
+aws s3 rb --force "s3://${bucket_name}" --region $region


### PR DESCRIPTION
Since Lightsail is now available in 10 Regions, change the deploy script
to default to the user's configured default Region rather than
hardcoding us-east-1.

Resolves #4.