### PR TITLE
added CLI named profile support

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -5,21 +5,22 @@ set -o errexit
 days=${DAYS:-30}
 schedule=${SCHEDULE:-rate(1 day)}
 region=${REGION:-$(aws configure get region)}
+profile=${AWS_PROFILE:default}
 
 bucket_name="temp-lightsail-auto-snapshots-$(openssl rand -hex 8)"
 
-aws s3 mb "s3://${bucket_name}" --region $region
+aws --profile $profile s3 mb "s3://${bucket_name}" --region $region
 
-aws cloudformation package \
+aws --profile $profile cloudformation package \
   --output-template-file deploy/output.yaml \
   --template-file lightsail-auto-snapshots.yaml \
   --s3-bucket="${bucket_name}"
 
-aws cloudformation deploy \
+aws --profile $profile cloudformation deploy \
   --template-file deploy/output.yaml \
   --stack-name LightsailAutoSnapshots \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides "RetentionDays=${days}" "Schedule=${schedule}" \
   --region $region
 
-aws s3 rb --force "s3://${bucket_name}" --region $region
+aws --profile $profile s3 rb --force "s3://${bucket_name}" --region $region


### PR DESCRIPTION
This pull request adds in named profile support, by the user declaring AWS_PROFILE in their CLI environment or at runtime of bin/deploy